### PR TITLE
Add an option to skip the reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Role Variables
 | `rhel8stig_dns_servers` | `8.8.8.8 and 8.8.4.4` | To conform to STIG standards you need two DNS servers, parameter is in list form |
 | `rhel8stig_nfs_mounts` | `vars` | NFS file system mounts pull automatcially with prelim task |
 | `rhel8stig_nfs_mounts_query` | `[?starts_with(fstype, 'nfs')].mount` | The query for mounts |
+| `rhel8stig_skip_reboot` | `false` | Whether or not to skip the reboot |
 
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,9 @@ rhel8stig_system_is_container: false
 # system_is_ec2 toggle will disable tasks that fail on Amazon EC2 instances. Set true to skip and false to run tasks
 system_is_ec2: false
 
+# Whether to skip the reboot
+rhel8stig_skip_reboot: false
+
 # These variables correspond with the STIG IDs defined in the STIG and allows you to enable/disable specific rules.
 # PLEASE NOTE: These work in coordination with the cat1, cat2, cat3 group variables. You must enable an entire group
 # in order for the variables below to take effect.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -128,3 +128,4 @@
   shell: sleep 3; reboot
   async: 15
   poll: 0
+  when: not rhel8stig_skip_reboot


### PR DESCRIPTION
Adds a variable to optionally skip rebooting.

Rationale:
When building images with a tool like Packer, the reboot can be disruptive. Packer specifically can deal with this; the issue is FIPS mode. Currently the Go SSH library used in Packer does not use SHA256 fingerprints when authenticating with SSH keys. After the reboot, Packer's SSH connection gets rejected and it can't continue provisioning or even issue the shutdown command if the role is the last provisioning step.

Signed-off-by: Dan Barr <dan@dbarr.com>