### PR TITLE
Minor bugfixes:

### DIFF
--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -263,7 +263,7 @@
       - name: "HIGH | RHEL-08-020330 | PATCH | RHEL 8 must not have accounts configured with blank or null passwords. | Remove nullok"
         replace:
             path: "{{ item }}"
-            regexp: 'nullok '
+            regexp: ' nullok'
             replace: ''
         with_items:
             - /etc/pam.d/system-auth

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1890,7 +1890,7 @@
         lineinfile:
             path: "/etc/security/faillock.conf"
             regexp: '^fail_interval =|^\# fail_interval ='
-            line: "fail_interval = {{ rhel8stig_pam_faillock.interval }} }}"
+            line: "fail_interval = {{ rhel8stig_pam_faillock.interval }}"
         with_items:
             - system-auth
             - password-auth
@@ -5373,7 +5373,7 @@
   lineinfile:
       path: /etc/ssh/sshd_config
       regexp: '(?i)^#?X11Forwarding'
-      line: 'X11Forwarding yes'
+      line: 'X11Forwarding no'
       create: yes
       owner: root
       group: root


### PR DESCRIPTION
* **Disabled** X11 forwarding for RHEL-08-040340
* Fixed typo, extra ' }}', in RHEL-020013
* Moved space in regex before 'nullok' to after 'nullok' in case 'nullok' is at the end of line in RHEL-08-020330
Signed-off-by: David Carlo <dcarlo@swillers.com>