### PR TITLE
Fix superuser for EFI boot

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -33,16 +33,17 @@
 
 - name: confirm grub2 user cfg
   stat:
-      path: /boot/grub2/user.cfg
+      path: "{{ rhel8stig_grub_cfg_path | dirname }}/user.cfg"
   register: rhel8stig_grub2_user_cfg
+  changed_when: rhel8stig_grub2_user_cfg.stat.exists
   notify: make grub2 config
 
 - name: make grub2 config
   command: /usr/sbin/grub2-mkconfig --output={{ rhel8stig_grub_cfg_path }}
   when:
-      - rhel7stig_grub2_user_cfg.stat.exists
-      - not rhel7stig_skip_for_travis
-      - not rhel7stig_system_is_container
+      - rhel8stig_grub2_user_cfg.stat.exists
+      - not rhel8stig_skip_for_travis
+      - not rhel8stig_system_is_container
 
 - name: copy grub2 config to BIOS/UEFI to satisfy benchmark
   listen: make grub2 config

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -155,12 +155,12 @@
       - name: |
             "RHEL-08-010140 | HIGH | PATCH | RHEL 8 operating systems booted with United Extensible Firmware Interface (UEFI) implemented must require authentication upon booting into single-user mode and maintenance. | Set UEFI superusers"
             "RHEL-08-010150 | HIGH | PATCH | RHEL 8 operating systems booted with a BIOS must require authentication upon booting into single-user and maintenance modes. | Set UEFI superusers"
-        lineinfile:
-            dest: "{{ rhel8stig_grub_cfg_path | dirname }}/grub.cfg"
-            regexp: '^set superusers'
-            line: 'set superusers="{{ rhel8stig_boot_superuser }}"'
-            insertafter: '### BEGIN /etc/grub.d/01_users ###'
+        replace:
+            path: "/etc/grub.d/01_users"
+            regexp: 'root'
+            replace: "{{ rhel8stig_boot_superuser }}"
         notify: confirm grub2 user cfg
+
   when:
       - not system_is_ec2
       - rhel_08_010140 or


### PR DESCRIPTION
**Overall Review of Changes:**
current way of setting the superuser directly in grub.cfg does not work, the way it is set, it will be ignored, the following config is generated:
```
### BEGIN /etc/grub.d/01_users ###
set superusers="someuser"
if [ -f ${prefix}/user.cfg ]; then
  source ${prefix}/user.cfg
  if [ -n "${GRUB2_PASSWORD}" ]; then
    set superusers="root"
    export superusers
    password_pbkdf2 root ${GRUB2_PASSWORD}
  fi
fi
 ### END /etc/grub.d/01_users ###
```

grub.cfg should not be edited directly, files in /etc/grub.d should be used (in this case /etc/grub.d/01_users

with this pull request config is generated as follows and handlers are correctly fired to generate grub.cfg:

```
### BEGIN /etc/grub.d/01_users ###
if [ -f ${prefix}/user.cfg ]; then
  source ${prefix}/user.cfg
  if [ -n "${GRUB2_PASSWORD}" ]; then
    set superusers="someuser"
    export superusers
    password_pbkdf2 someuser ${GRUB2_PASSWORD}
  fi
fi
 ### END /etc/grub.d/01_users ###
```

**Issue Fixes:**

**Enhancements:**

**How has this been tested?:**

1.  Set vars rhel8stig_bootloader_password_hash and rhel8stig_boot_superuser use any other username than 'root'
2.  Run playbook
3.  Reboot, press e in grub boot menu
4. enter username
5. enter password
6. boot entry should be able to edit

Without this pull request, only username 'root' works, any other username will not work/will be ignored and 'root' will be used

