### PR TITLE
Fix Masked nftables Service

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: '{{ hosts }}'
   become: true
   vars:
       is_container: false

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: '{{ hosts }}'
+- hosts: all
   become: true
   vars:
       is_container: false

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -6316,6 +6316,7 @@
             name: nftables
             state: started
             enabled: yes
+            masked: no
 
       - name: "MEDIUM | RHEL-08-040150 | PATCH | A firewall must be able to protect against or limit the effects of Denial of Service (DoS) attacks by ensuring RHEL 8 can implement rate-limiting measures on impacted network interfaces. | Configure FirewallBackend"
         lineinfile:


### PR DESCRIPTION
**Overall Review of Changes:**
If nftables service is masked this step fails, added config to unmask

**Issue Fixes:**
Step fails if nftables service is masked

**Enhancements:**
Will prevent step from failing if nftables service is masked

**How has this been tested?:**
Step was failing when nftables service was masked, added config, step no longer fails when nftables service is masked
