### PR TITLE
Permit the use of service name or protocol port.

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -6051,7 +6051,8 @@
             zone: "{{ rhel8stig_custom_firewall_zone }}"
             permanent: true
             state: enabled
-            service: "{{ item }}"
+            service: "{{ (item == (item | regex_search('^[a-z]+$')))        | bool | ternary(item, omit) }}"
+            port:    "{{ (item == (item | regex_search('^[0-9]+/[a-z]+$'))) | bool | ternary(item, omit) }}"
         with_items:
             - "{{ rhel8stig_white_list_services }}"
 


### PR DESCRIPTION
While adding a port for an AV scanner, it didn't have a named port so we couldn't add it to the 'rhel8stig_white_list_services' list variable.  Adding the "regex_search()" filter automatically uses the correct module parameter based on the value of each item in the list variable.

**Overall Review of Changes:**
This adds the ability to use port information (port # / protocol type) along with the named service when pre-defining whitelisted services.

**Enhancements:**
This permits the `rhel8stig_white_list_services` to list `port/protocol` entries alongside named services.

**How has this been tested?:**
This modification has been made to a playbook and correctly applies the firewall setting for each type of valid service or port entry.
