### PR TITLE
ARustam_dev

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ rhel8stig_workaround_for_ssg_benchmark: true
 rhel8stig_system_is_chroot: "{{ ansible_is_chroot | default(False) }}"
 
 # tweak role to run in a non-privileged container (default value)- dynamically discovered in tasks/main.yml
-system_is_container: false
+rhel8stig_system_is_container: false
 
 # Place to find the container yml file for your environment - /vars/...
 container_vars_file: is_container.yml

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,7 +3,7 @@
   systemd:
       daemon_reload: true
   when:
-      - not system_is_container
+      - not rhel8stig_system_is_container
 
 - name: update sysctl
   template:
@@ -63,7 +63,7 @@
   when:
       - rhel8stig_grub2_user_cfg.stat.exists
       - not rhel8stig_skip_for_travis
-      - not system_is_container
+      - not rhel8stig_system_is_container
 
 - name: copy grub2 config to BIOS/UEFI to satisfy benchmark
   listen: make grub2 config
@@ -81,7 +81,7 @@
       - rhel8stig_grub2_user_cfg.stat.exists
       - rhel8stig_workaround_for_disa_benchmark
       - not rhel8stig_skip_for_travis
-      - not system_is_container
+      - not rhel8stig_system_is_container
 
 - name: "restart {{ rhel8stig_time_service }}"
   service:
@@ -90,7 +90,7 @@
   when:
       - not rhel8stig_skip_for_travis
       - not rhel8stig_system_is_chroot
-      - not system_is_container
+      - not rhel8stig_system_is_container
 
 - name: update auditd
   template:
@@ -108,7 +108,7 @@
   when:
       - not rhel8stig_skip_for_travis
       - not rhel8stig_system_is_chroot
-      - not system_is_container
+      - not rhel8stig_system_is_container
 
 - name: rebuild initramfs
   command: dracut -f

--- a/tasks/fix-cat1.yml
+++ b/tasks/fix-cat1.yml
@@ -127,7 +127,7 @@
             - not ansible_check_mode or
               rhel_08_010020_audit.rc > 1
   when:
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - rhel_08_010020
   tags:
       - RHEL-08-010020
@@ -191,7 +191,7 @@
             mode: 0640
         notify: confirm grub2 user cfg
   when:
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - not system_is_ec2
       - rhel_08_010140 or
         rhel_08_010150
@@ -413,7 +413,7 @@
         notify: systemctl daemon-reload
   when:
       - rhel_08_040170
-      - not system_is_container
+      - not rhel8stig_system_is_container
   tags:
       - RHEL-08-040170
       - CAT1
@@ -472,7 +472,7 @@
   notify: systemctl daemon-reload
   when:
       - rhel_08_040172
-      - not system_is_container
+      - not rhel8stig_system_is_container
   tags:
       - RHEL-08-040172
       - CAT1

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -450,7 +450,7 @@
   notify: change_requires_reboot
   when:
       - rhel_08_010170 or rhel_08_010450
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - rhel8stig_disruption_high
   tags:
       - CAT2
@@ -541,7 +541,7 @@
       - rhel_08_010210 or
         rhel_08_010220 or
         rhel_08_010230
-      - not system_is_container
+      - not rhel8stig_system_is_container
   tags:
       - CAT2
       - RHEL-08-010210
@@ -1303,7 +1303,7 @@
       state: present
   when:
       - rhel_08_010410
-      - not system_is_container
+      - not rhel8stig_system_is_container
   tags:
       - RHEL-08-010410
       - CAT2
@@ -1892,7 +1892,7 @@
             removable_mount2: "{{ ansible_mounts | json_query('[?mount == `/mnt`] | [0]') }}"
   when:
       - rhel_08_010600
-      - not (rhel8stig_system_is_chroot and system_is_container)
+      - not (rhel8stig_system_is_chroot and rhel8stig_system_is_container)
   tags:
       - RHEL-08-010600
       - CAT2
@@ -2279,7 +2279,7 @@
   when:
       - rhel_08_010680
       - not rhel8stig_system_is_chroot
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - not system_is_ec2
   tags:
       - RHEL-08-010680
@@ -3152,7 +3152,7 @@
   when:
       - rhel_08_020027 or
         rhel_08_020028
-      - not system_is_container
+      - not rhel8stig_system_is_container
   tags:
       - RHEL-08-020027
       - RHEL-08-020028
@@ -5745,7 +5745,7 @@
         when:
             - rhel_08_040030
             - not rhel8stig_system_is_chroot
-            - not system_is_container
+            - not rhel8stig_system_is_container
             - rhel8stig_firewall_service == "firewalld"
             - rhel8stig_start_firewall_service
         tags:
@@ -5780,7 +5780,7 @@
         when:
             - rhel_08_040030
             - not rhel8stig_system_is_chroot
-            - not system_is_container
+            - not rhel8stig_system_is_container
             - rhel8stig_firewall_service == "iptables"
             - rhel8stig_start_firewall_service
         tags:
@@ -6006,7 +6006,7 @@
   notify: change_requires_reboot
   when:
       - rhel_08_040111
-      - not system_is_container
+      - not rhel8stig_system_is_container
   tags:
       - RHEL-08-040111
       - CAT2
@@ -6342,7 +6342,7 @@
       - rhel_08_040139 or
         rhel_08_040140 or
         rhel_08_040141
-      - not system_is_container
+      - not rhel8stig_system_is_container
   tags:
       - RHEL-08-040139
       - RHEL-08-040140
@@ -6862,7 +6862,7 @@
   when:
       - rhel_08_040330
       - not rhel8stig_net_promisc_mode_required
-      - not system_is_container
+      - not rhel8stig_system_is_container
   tags:
       - RHEL-08-040330
       - CAT2

--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -117,7 +117,7 @@
   when:
       - rhel_08_010471 or
         rhel_08_010472
-      - not system_is_container
+      - not rhel8stig_system_is_container
   tags:
       - RHEL-08-010471
       - RHEL-08-010472

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
   block:
       - name: Discover and set container variable if required
         set_fact:
-            system_is_container: true
+            rhel8stig_system_is_container: true
 
       - name: Load variable for container
         include_vars:
@@ -38,7 +38,7 @@
         debug:
             msg: system has been discovered as a container
         when:
-            - system_is_container
+            - rhel8stig_system_is_container
   when:
       - ansible_connection == 'docker' or
         ansible_virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]
@@ -53,7 +53,7 @@
 
   when:
       - not system_is_ec2
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - rhel_08_010140 or
         rhel_08_010150
   tags:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -50,7 +50,7 @@
   dnf:
       name: grub2-tools
   when:
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - "'grub2-tools' not in ansible_facts.packages"
       - rhel_08_010020 or
         rhel_08_010140 or
@@ -103,7 +103,7 @@
   dnf:
       name: cronie
   when:
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - "'cronie' not in ansible_facts.packages"
       - rhel_08_010360
   tags:
@@ -153,7 +153,7 @@
   dnf:
       name: rsyslog
   when:
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - rhel_08_010070 or
         rhel_08_030010
       - "'rsyslog' not in ansible_facts.packages"
@@ -181,7 +181,7 @@
   dnf:
       name: audispd-plugins
   when:
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - rhel_08_030620 or
         rhel_08_030630 or
         rhel_08_030640 or
@@ -235,7 +235,7 @@
         changed_when: not rhel8stig_aide_db_status.stat.exists
         notify: "{{ rhel8stig_aide_handler }}"
   when:
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - rhel_08_010360 or
         rhel_08_010380 or
         rhel_08_040310
@@ -253,7 +253,7 @@
       name: libselinux-utils
       state: present
   when:
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - "'libselinux-utils' not in ansible_facts.packages"
       - rhel_08_010170 or
         rhel_08_010450
@@ -414,7 +414,7 @@
             group: root
         register: faillock_dir
   when:
-      - not system_is_container
+      - not rhel8stig_system_is_container
       - rhel_08_020017
       - rhel_08_020027
       - rhel_08_020028

--- a/templates/99-sysctl.conf.j2
+++ b/templates/99-sysctl.conf.j2
@@ -52,7 +52,7 @@ kernel.core_pattern = |/bin/false
 net.ipv4.conf.default.accept_redirects = 0
 {% endif %}
 
-{% if rhel_08_040210 %}
+{% if rhel_08_040210 and rhel8stig_ipv6_required %}
 # RHEL-08-040210
 net.ipv6.conf.default.accept_redirects = 0
 {% endif %}
@@ -82,27 +82,27 @@ net.ipv6.conf.all.accept_source_route = 0
 net.ipv4.conf.default.accept_source_route = 0
 {% endif %}
 
-{% if rhel_08_040250 %}
+{% if rhel_08_040250 and rhel8stig_ipv6_required %}
 # RHEL-08-040250
 net.ipv6.conf.default.accept_source_route = 0
 {% endif %}
 
-{% if rhel_08_040259 %}
+{% if rhel_08_040259 and not rhel8stig_system_is_router %}
 # RHEL-08-040259
 net.ipv4.ip_forward = 0
 {% endif %}
 
-{% if rhel_08_040260 %}
+{% if rhel_08_040260 and not rhel8stig_system_is_router %}
 # RHEL-08-040260
 net.ipv6.conf.all.forwarding = 0
 {% endif %}
 
-{% if rhel_08_040261 %}
+{% if rhel_08_040261 and rhel8stig_ipv6_required and not rhel8stig_system_is_router %}
 # RHEL-08-040261
 net.ipv6.conf.all.accept_ra = 0
 {% endif %}
 
-{% if rhel_08_040262 %}
+{% if rhel_08_040262 and rhel8stig_ipv6_required and not rhel8stig_system_is_router %}
 # RHEL-08-040262
 net.ipv6.conf.default.accept_ra = 0
 {% endif %}
@@ -117,7 +117,7 @@ net.ipv4.conf.default.send_redirects = 0
 net.ipv4.conf.all.accept_redirects = 0
 {% endif %}
 
-{% if rhel_08_040280 %}
+{% if rhel_08_040280 and rhel8stig_ipv6_required %}
 # RHEL-08-040280
 net.ipv6.conf.all.accept_redirects = 0
 {% endif %}


### PR DESCRIPTION
**Overall Review of Changes:**
Changes variable name for container from "system_is_container" to "rhel8stig_system_is_container".
Added "rhel8stig" prefix to fix mismatch and to follow variable naming practices in the role.

**Issue Fixes:**
N/A

**Enhancements:**
Variable name mismatch within the role. 
"**system_is_container**" in:
- /defaults/main.yml
- /handlers/main.yml
- /tasks/fix-cat1.yml
- /tasks/fix-cat2.yml
- /tasks/fix-cat3.yml
- /tasks/main.yml
- /tasks/prelim.yml

"**rhel8stig_system_is_container**" in:
- /vars/main.yml

**How has this been tested?:**
Manual
