### PR TITLE
Updated fapolicyd Rules Directory Support - Issue 93 Fix

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -48,7 +48,7 @@
 
 - name: generate fapolicyd rules
   command: fagenrules --load
-  when: rules_dir.stat.exists
+  when: rhel_08_040137_rules_dir.stat.exists
 
 - name: restart fapolicyd
   service:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -46,6 +46,10 @@
       name: rsyslog
       state: restarted
 
+- name: generate fapolicyd rules
+  command: fagenrules --load
+  when: rules_dir is defined and not rules_dir.stat.exists
+
 - name: restart fapolicyd
   service:
       name: fapolicyd

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -48,7 +48,7 @@
 
 - name: generate fapolicyd rules
   command: fagenrules --load
-  when: rules_dir is defined and not rules_dir.stat.exists
+  when: rules_dir.stat.exists
 
 - name: restart fapolicyd
   service:

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -6284,13 +6284,13 @@
       - name: "MEDIUM | RHEL-08-040137 | PATCH | The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs. | Check for rules.d/ directory"
         stat:
           path: /etc/fapolicyd/rules.d/
-        register: rules_dir
+        register: rhel_08_040137_rules_dir
 
       - name: "MEDIUM | RHEL-08-040137 | PATCH | The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs. | Set fapolicy whitelist "
         lineinfile:
-            create: yes
-            path: "{{ '/etc/fapolicyd/rules.d/99-stig.rules' if rules_dir.stat.exists else '/etc/fapolicyd/fapolicyd.rules' }}"
+            path: "{{ '/etc/fapolicyd/rules.d/99-stig.rules' if rhel_08_040137_rules_dir.stat.exists else '/etc/fapolicyd/fapolicyd.rules' }}"
             line: "{{ item }}"
+            create: yes
         with_items:
             - "allow exe={{ ansible_python.executable }} : ftype=text/x-python"
             - "{{ rhel8stig_fapolicy_white_list }}"

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -6281,6 +6281,11 @@
 
 - name: "MEDIUM | RHEL-08-040137 | PATCH | The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs."
   block:
+      - name: Check if Rules Directory Exists
+        stat:
+          path: /etc/fapolicyd/rules.d/
+        register: rules_dir
+
       - name: "MEDIUM | RHEL-08-040137 | PATCH | The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs. | Set fapolicy whitelist "
         lineinfile:
             path: /etc/fapolicyd/fapolicyd.rules

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -6281,19 +6281,21 @@
 
 - name: "MEDIUM | RHEL-08-040137 | PATCH | The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs."
   block:
-      - name: Check if Rules Directory Exists
+      - name: "MEDIUM | RHEL-08-040137 | PATCH | The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs. | Check for rules.d/ directory"
         stat:
           path: /etc/fapolicyd/rules.d/
         register: rules_dir
 
       - name: "MEDIUM | RHEL-08-040137 | PATCH | The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs. | Set fapolicy whitelist "
         lineinfile:
-            path: /etc/fapolicyd/fapolicyd.rules
+            create: yes
+            path: "{{ '/etc/fapolicyd/rules.d/99-stig.rules' if rules_dir.stat.exists else '/etc/fapolicyd/fapolicyd.rules' }}"
             line: "{{ item }}"
         with_items:
             - "allow exe={{ ansible_python.executable }} : ftype=text/x-python"
             - "{{ rhel8stig_fapolicy_white_list }}"
         notify:
+            - generate fapolicyd rules
             - restart fapolicyd
 
       - name: "MEDIUM | RHEL-08-040137 | PATCH | The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs. | Set fapolicy permissive 0"


### PR DESCRIPTION
**Overall Review of Changes:**
fapolicy updated to use rules directory and current script configurations will break with the updated fapolicy version. These updates now create the required fapolicy rules in the `rules.d` folder.

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL8-STIG/issues/93

**Enhancements:**
Added necessary steps to determine if the `rules.d` directory should be used.

**How has this been tested?:**
Tested against a CentOS 8 Stream Minimal OS
