### PR TITLE
ability to skip supported os check

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Refer to [RHEL8-STIG-Audit](https://github.com/ansible-lockdown/RHEL8-STIG-Audit
 
 ## Requirements
 
-RHEL/Rocky/AlmaLinux 8 - Other versions are not supported.
-Access to download or add the goss binary and content to the system if using auditing. options are available on how to get the content to the system.
+- RHEL/Rocky/AlmaLinux 8 - Other versions are not supported.
+- Other OSs can be checked by changing the skip_os_check to true for testing purposes.
+- Access to download or add the goss binary and content to the system if using auditing. options are available on how to get the content to the system.
 
 ### General
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ benchmark: RHEL8-STIG
 # Whether to skip the reboot
 rhel8cis_skip_reboot: true
 
+# Whether to skip the OS check for supported OS's
+skip_os_check: false
+
 rhel8stig_cat1_patch: true
 rhel8stig_cat2_patch: true
 rhel8stig_cat3_patch: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,8 @@
       that: (ansible_distribution != 'CentOS' and ansible_os_family == 'RedHat' or ansible_os_family == "Rocky") and ansible_distribution_major_version is version_compare('8', '==')
       fail_msg: "This role can only be run against RHEL/Rocky 8. {{ ansible_distribution }} {{ ansible_distribution_major_version }} is not supported."
       success_msg: "This role is running against a supported OS {{ ansible_distribution }} {{ ansible_distribution_major_version }}"
+  when:
+      - not skip_os_check
   tags:
       - always
 


### PR DESCRIPTION
Signed-off-by: Mark Bolwell <mark.bollyuk@gmail.com>

**Overall Review of Changes:**
Attempt to enable end users to be able to run against non supported OSs

**Issue Fixes:**
#96 

**Enhancements:**
Ability to skip supported OS checks

**How has this been tested?:**
Manually
