### PR TITLE
Improvements to allow env settings for audit script

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -885,6 +885,11 @@ rhel8stig_tmux_lock_after_time: 900
 rhel8stig_sudo_timestamp_timeout: 1
 
 #### Goss Configuration Settings ####
+# Set correct env for the run_audit.sh script from https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
+audit_run_script_environment:
+    AUDIT_BIN: "{{ audit_bin }}"
+    AUDIT_FILE: 'goss.yml'
+    AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
 
 ### Goss binary settings ###
 goss_version:

--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -2,6 +2,7 @@
 
 - name: "Post Audit | Run post_remediation {{ benchmark }} audit"
   shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g {{ group_names }}"
+  environment: "{{ audit_run_script_environment|default({}) }}"
   changed_when: rhel8stig_run_post_remediation.rc == 0
   register: rhel8stig_run_post_remediation
   vars:

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -90,6 +90,7 @@
 
 - name: "Pre Audit | Run pre_remediation {{ benchmark }} audit"
   shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }}"
+  environment: "{{ audit_run_script_environment|default({}) }}"
   changed_when: rhel8stig_run_pre_remediation.rc == 0
   register: rhel8stig_run_pre_remediation
   vars:


### PR DESCRIPTION
Signed-off-by: Mark Bolwell <mark.bollyuk@gmail.com>

**Overall Review of Changes:**
Ability to change the direcyories for the audit via variables
thanks to
https://github.com/ansible-lockdown/RHEL8-CIS/pull/191 - @pavloos


**Enhancements:**
ability to change to change the variables for the default audit location from /var/tmp

**How has this been tested?:**
For RHEL8-CIS same scripts layout and variables are used
