### PR TITLE
Updated STIG-ID RHEL-08-040111 to blacklist bluetooth kernel module

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -5995,15 +5995,31 @@
       - wifi
 
 - name: "MEDIUM | RHEL-08-040111 | PATCH | RHEL 8 Bluetooth must be disabled."
-  lineinfile:
-      path: /etc/modprobe.d/bluetooth.conf
-      regexp: '^install bluetooth '
-      line: "install bluetooth /bin/true"
-      create: yes
-      owner: root
-      group: root
-      mode: 0640
-  notify: change_requires_reboot
+  block:
+    - name: "MEDIUM | RHEL-08-040111 | PATCH | RHEL 8 Bluetooth must be disabled. | Disable Bluetooth"
+      lineinfile:
+        path: /etc/modprobe.d/bluetooth.conf
+        regexp: '^install bluetooth '
+        line: "install bluetooth /bin/true"
+        create: yes
+        owner: root
+        group: root
+        mode: 0640
+      notify: change_requires_reboot      
+
+    - name: "MEDIUM | RHEL-08-040111 | PATCH | RHEL 8 Bluetooth must be disabled. | Disable Bluetooth kernel module"
+      lineinfile:
+          path: /etc/modprobe.d/blacklist.conf
+          create: yes
+          regexp: "{{ item.regexp }}"
+          line: "{{ item.line }}"
+          owner: root
+          group: root
+          mode: 0640
+          insertafter: "{{ item.insertafter }}"
+      notify: change_requires_reboot
+      with_items:
+          - { regexp: '^blacklist bluetooth', line: 'blacklist bluetooth', insertafter: '#blacklist bluetooth kernel module' }
   when:
       - rhel_08_040111
       - not system_is_container


### PR DESCRIPTION
Signed-off-by: Matthew Willis <matthew.willis@outlook.com>

**Overall Review of Changes:**
Updated STIG-ID RHEL-08-040111 to blacklist bluetooth kernel module

**Issue Fixes:**

Fix Text (F-33151r833335_fix)
--
Configure the operating system to disable the Bluetooth adapter when not in use.Build or modify the "/etc/modprobe.d/bluetooth.conf" file with the following line:install bluetooth /bin/trueDisable the ability to use the Bluetooth kernel module.$ sudo vi /etc/modprobe.d/blacklist.confAdd or update the line:blacklist bluetoothReboot the system for the settings to take effect.

```
Configure the operating system to disable the Bluetooth adapter when not in use.

Build or modify the "/etc/modprobe.d/bluetooth.conf" file with the following line:

install bluetooth /bin/true
Disable the ability to use the Bluetooth kernel module.
$ sudo vi /etc/modprobe.d/blacklist.conf

Add or update the line:blacklist bluetooth

Reboot the system for the settings to take effect.
```
