### PR TITLE
Updated permissions on /etc/pam.d/system-auth to 0644 from 0640.

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -3454,7 +3454,7 @@
       insertafter: '^password'
       owner: root
       group: root
-      mode: 0640
+      mode: 0644
   when:
       - rhel_08_020100
   tags:
@@ -3540,7 +3540,7 @@
             insertafter: '^password'
             owner: root
             group: root
-            mode: 0640
+            mode: 0644
         when: rhel_08_020103_pwquality_status.stdout | length == 0
 
       - name: "MEDIUM | RHEL-08-020103 | PATCH | RHEL 8 systems below version 8.4 must ensure the password complexity module in the password-auth file is configured for three retries or less. | Replace if already exists"
@@ -3828,7 +3828,7 @@
             insertafter: '^password'
             owner: root
             group: root
-            mode: 0640
+            mode: 0644
         when: rhel_08_020220_pwhistory_status.stdout | length == 0
 
       - name: "MEDIUM | RHEL-08-020220 | RHEL 8 must be configured in the password-auth file to prohibit password reuse for a minimum of five generations. | Set if pw required pwhistory exists"

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -3474,7 +3474,7 @@
       insertafter: '^password'
       owner: root
       group: root
-      mode: 0640
+      mode: 0644
   when:
       - rhel_08_020101
   tags:
@@ -3501,7 +3501,7 @@
             insertafter: '^password'
             owner: root
             group: root
-            mode: 0640
+            mode: 0644
         when: rhel_08_020102_pwquality_status.stdout | length == 0
 
       - name: "MEDIUM | RHEL-08-020102 | PATCH | RHEL 8 systems below version 8.4 must ensure the password complexity module in the system-auth file is configured for three retries or less. | Replace if already exists"
@@ -3866,7 +3866,7 @@
             insertafter: '^password'
             owner: root
             group: root
-            mode: 0640
+            mode: 0644
         when: rhel_08_020221_pwhistory_status.stdout | length == 0
 
       - name: "MEDIUM | RHEL-08-020221 | PATCH | RHEL 8 must be configured in the system-auth file to prohibit password reuse for a minimum of five generations. | Set if pw required pwhistory exists"


### PR DESCRIPTION
**Description of Issue**
The error is when a non elevated account goes into a locked-session, /etc/pam.d/vlock has 

```
#%PAM-1.0
auth    include     system-auth
account required    pam_permit.so
```

in the file, with the permissions of 0640 which is set with remediation tasks (RHEL-08-020101 and RHEL-08-020102). Meaning non-elevated users cannot use vlock to include system-auth since root:root 0640 is applied. When root sessions were locked, there were no issues using vlock to lock/unlock sessions. This only effected non-elevated users.

**Remediation**
I couldn't find it in the RHEL 8 STIG (or anywhere else) if that needed to be 0640 or 0644. As soon as permissions are set to the /etc/pam.d/system-auth to 0644, restart sssd  `systemctl restart sssd` , logged into a new session and successfully locked/unlocked both from tty and ssh sessions.

Updated /etc/pam.d/password-auth permission to 0644 as well.



**Issue Fixes:**
I believe this fixes issue [https://github.com/ansible-lockdown/RHEL8-STIG/issues/107](https://github.com/ansible-lockdown/RHEL8-STIG/issues/107). Not 100% sure, but I definitely experienced similar 'non-login' experience with TMUX sessions.


