### PR TITLE
(#131) Fix regular expression for RHEL-08-020040

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -3220,7 +3220,7 @@
       - name: "MEDIUM | RHEL-08-020040 | PATCH | RHEL 8 must enable a user session lock until that user re-establishes access using established identification and authentication procedures for command line sessions. | Configure tmux"
         lineinfile:
             path: /etc/tmux.conf
-            regexp: '^set \-g'
+            regexp: '^set -g lock-command'
             line: "set -g lock-command vlock"
             create: true
             owner: root


### PR DESCRIPTION
**Overall Review of Changes:**

- Fixes regex for RHEL-08-020040, to eliminate overwriting of other configuration lines (`set -g` is the beginning of EVERY LINE in a config, not just the intended line)

**Issue Fixes:**

- #131 

**How has this been tested?:**

- Tested in local copy against a VM
