### PR TITLE
(#134) Add missing check for UID range for RHEL-08-010740

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2484,6 +2484,7 @@
   when:
       - rhel_08_010740
       - (item.uid >= rhel8stig_interactive_uid_start | int)
+      - (item.uid <= rhel8stig_interactive_uid_stop | int)
   tags:
       - skip_ansible_lint
       - RHEL-08-010740


### PR DESCRIPTION
**Overall Review of Changes:**

Adds missing check for UID range

**Issue Fixes:**

- #134 

**How has this been tested?:**

Tested against VM to ensure the `nobody` user (UID 65534) was skipped correctly
