### PR TITLE
Changes fstype from static value of xfs to queried fstype value and uses queried value in mount tasks

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -6159,7 +6159,7 @@
             path: /tmp
             state: mounted
             src: "{{ tmp_mount.device }}"
-            fstype: xfs
+            fstype: "{{ tmp_mount.fstype }}"
             opts: "defaults{{ rhel_08_040123 | ternary (',nodev', '') }}{{ rhel_08_040124 | ternary (',nosuid', '') }}{{ rhel_08_040125 | ternary (',noexec', '') }}"
         vars:
             tmp_mount: "{{ ansible_mounts | json_query('[?mount == `/tmp`] | [0]') }}"
@@ -6206,7 +6206,7 @@
             path: /var/log
             state: mounted
             src: "{{ var_log_mount.device }}"
-            fstype: xfs
+            fstype: "{{ var_log_mount.fstype }}"
             opts: "defaults{{ rhel_08_040126 | ternary (',nodev', '') }}{{ rhel_08_040127 | ternary (',nosuid', '') }}{{ rhel_08_040128 | ternary (',noexec', '') }}"
         vars:
             var_log_mount: "{{ ansible_mounts | json_query('[?mount == `/var/log`] | [0]') }}"
@@ -6252,7 +6252,7 @@
             path: /var/log/audit
             state: mounted
             src: "{{ audit_mount.device }}"
-            fstype: xfs
+            fstype: "{{ audit_mount.fstype }}"
             opts: "defaults{{ rhel_08_040129 | ternary (',nodev', '') }}{{ rhel_08_040130 | ternary (',nosuid', '') }}{{ rhel_08_040131 | ternary (',noexec', '') }}"
         vars:
             audit_mount: "{{ ansible_mounts | json_query('[?mount == `/var/log/audit`] | [0]') }}"
@@ -6298,7 +6298,7 @@
             path: /var/tmp
             state: mounted
             src: "{{ var_tmp_mount.device }}"
-            fstype: xfs
+            fstype: "{{ var_tmp_mount.fstype }}"
             opts: "defaults{{ rhel_08_040132 | ternary (',nodev', '') }}{{ rhel_08_040133 | ternary (',nosuid', '') }}{{ rhel_08_040134 | ternary (',noexec', '') }}"
         vars:
             var_tmp_mount: "{{ ansible_mounts | json_query('[?mount == `/var/tmp`] | [0]') }}"


### PR DESCRIPTION
For RHEL-08-040123, RHEL-08-040124, and RHEL-08-040125 tasks in fix-cat2.yml

xfs is used as as a static value for the fstype parameter in some tasks using the mount module instead of using the queried fstype value for the respective file system.  The queried value is available to use and is already used in other tasks in fix-cat2.yml.  I.E. "{{ home_mount.fstype }}"

/tmp, /var/log, /var/log/audit, and /var/tmp mount tasks are corrected by this commit.

Using the queried fstype value instead of xfs as a hard coded static value, prevents a mount error and resulting dracut emergency shell when rebooting due to bad or incorrect fstype set in fstab, when xfs is not used as the actual file system for these mounts.  For example, when using ext4.

This has been tested via kickstart using ext4 as the underlying file system for all logical volumes on a prototype testing system, and the system reboots properly after applying RHEL8-STIG with these changes.  In this case, ext4 is properly added as the fstype in /etc/fstab