### PR TITLE
Fix fapolicyd required check

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -6372,7 +6372,7 @@
         notify:
             - generate fapolicyd rules
             - restart fapolicyd
-        when: ansible_distribution_version is version('8.4', '>=')
+        when: ansible_distribution_version is version('8.4', '>=') and rhel_08_040137_rules_dir.stat.isdir
 
       - name: "MEDIUM | RHEL-08-040137 | PATCH | The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs. | Set fapolicy whitelist on older than 8.4"
         lineinfile:
@@ -6385,7 +6385,7 @@
         notify:
             - generate fapolicyd rules
             - restart fapolicyd
-        when: ansible_distribution_version is version('8.4', '<=')
+        when: ansible_distribution_version is version('8.4', '<=') and not rhel_08_040137_rules_dir.stat.isdir
 
       - name: "MEDIUM | RHEL-08-040137 | PATCH | The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs. | Set fapolicy permissive 0"
         lineinfile:


### PR DESCRIPTION
**Overall Review of Changes:**
fapolicyd genrules will fail if it sees the old `/etc/fapolicyd/fapolicyd.rules` with updated versions of fapolicyd. There is a rule that checks that stat for the existance of the new `/etc/fapolicyd/rules.d/` folder, however the results of this were not being used in the subsequent rules. This appears to have been an accidental omission, and this just resolves that.

**How has this been tested?:**
Tested against CentOS 8 Stream Minimal Install and worked well
