### PR TITLE
Remove trigger update sysctl task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -157,17 +157,6 @@
       - CAT3
       - low
 
-- name: trigger update sysctl
-  command: /bin/true
-  changed_when: rhel8stig_trigger_update_sysctl.rc == 0
-  check_mode: false
-  register: rhel8stig_trigger_update_sysctl
-  notify: update sysctl
-  tags:
-      - CAT1
-      - CAT2
-      - CAT3
-
 - name: flush handlers
   meta: flush_handlers
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Removed trigger update sysctl task that didn't do anything, since all the sysctl tasks already notify that handler.

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL8-STIG/issues/165

**Enhancements:**
N/A

**How has this been tested?:**
This has been run against RHEL 8 servers
