### PR TITLE
RHEL-08-010295 Remove Permission Changes to gnutls.config

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -851,10 +851,6 @@
       regexp: '^(.*)\+VERS-ALL:'
       line: '\1{{ rhel8stig_gnutls_encryption }}'
       backrefs: true
-      create: true
-      owner: root
-      group: root
-      mode: 0640
   notify: change_requires_reboot
   when:
       - rhel_08_010295


### PR DESCRIPTION
**Overall Review of Changes:**
This removes permission changes that were in the task for RHEL-08-010295

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL8-STIG/issues/166

**Enhancements:**
N/A

**How has this been tested?:**
This has been run against RHEL 8 servers.
