### PR TITLE
Correct abrt* Package Removal

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -5670,10 +5670,9 @@
       - chrony
 
 - name: "MEDIUM | RHEL-08-040001 | PATCH | RHEL 8 must not have any automated bug reporting tools installed."
-  shell: dnf remove abrt*
-  failed_when: false
-  args:
-      warn: false
+  package:
+    name: "abrt*"
+    state: absent
   when:
       - rhel_08_040001
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Switch RHEL-08-040001 to use package to correctly remove abrt* packages

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL8-STIG/issues/173

**Enhancements:**
N/A

**How has this been tested?:**
Ran against RHEL 8 server
