### PR TITLE
Adds default variables and task to modify getent user enumeration com…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -482,7 +482,7 @@ rhel8stig_autofs_remote_home_dirs: false
 
 #The local mount point used by autofs to mount remote home directory to.  This location will be excluded during getent user enumeration, if rhel8stig_autofs_remote_home_dirs is true
 rhel8stig_auto_mount_home_dirs_local_mount_point: "/home/"
-    
+
 #The default shell command to gather local interactive user directories
 ## NOTE: You will need to adjust the UID range in parenthesis below.
 ## ALSO NOTE: We weed out any user with a home dir not in standard locations because interactive users shouldn't have those paths as a home dir. Add or removed directory paths as needed below.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -477,6 +477,17 @@ rhel8stig_smartcard: false
 # Configure your smartcard driver
 rhel8stig_smartcarddriver: cackey
 
+#Whether or not system uses remote automounted home directories via autofs
+rhel8stig_autofs_remote_home_dirs: false
+
+#The local mount point used by autofs to mount remote home directory to.  This location will be excluded during getent user enumeration, if rhel8stig_autofs_remote_home_dirs is true
+rhel8stig_auto_mount_home_dirs_local_mount_point: "/home/"
+    
+#The default shell command to gather local interactive user directories
+## NOTE: You will need to adjust the UID range in parenthesis below.
+## ALSO NOTE: We weed out any user with a home dir not in standard locations because interactive users shouldn't have those paths as a home dir. Add or removed directory paths as needed below.
+local_interactive_user_dir_command: "getent passwd { {{ rhel8stig_int_gid }}..65535} | cut -d: -f6 | sort -u | grep -v '/var/' | grep -v '/nonexistent/*' | grep -v '/run/*'"
+
 # IPv6 required
 rhel8stig_ipv6_required: true
 

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -116,7 +116,7 @@
       - RHEL-08-010750
       - RHEL-08-020320
 
-- name: "PRELIM | RHEL-08-010690 Ensure user enumeration command is modified when autofs remote home directories are used"
+- name: "PRELIM | RHEL-08-010690 Ensure user enumeration command is modified when autofs remote home directories are in use"
   block:
       - name: Ensure that rhel8stig_auto_mount_home_dirs_local_mount_point is defined and not length zero
         assert:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -116,7 +116,7 @@
       - RHEL-08-010750
       - RHEL-08-020320
 
-- name: Ensure user enumeration command is modified when autofs remote home directories are used
+- name: "PRELIM | RHEL-08-010690 Ensure user enumeration command is modified when autofs remote home directories are used"
   block:
       - name: Ensure that rhel8stig_auto_mount_home_dirs_local_mount_point is defined and not length zero
         assert:
@@ -127,8 +127,9 @@
       - name: Modify local_interactive_user_dir_command to exclude remote automounted home directories
         set_fact:
             local_interactive_user_dir_command: "{{ local_interactive_user_dir_command }} | grep -v '{{ rhel8stig_auto_mount_home_dirs_local_mount_point }}"
+
   when:
-      - rhel8stig_autofs_remote_home_dirs
+    - rhel8stig_autofs_remote_home_dirs
   tags:
     - RHEL-08-010690
     - complexity-high

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -116,11 +116,25 @@
       - RHEL-08-010750
       - RHEL-08-020320
 
-## NOTE: You will need to adjust the UID range in parenthases below.
-## ALSO NOTE: We weed out any user with a home dir not in standard locations because interactive users shouldn't have those paths as a home dir. Add or removed directory paths as needed below.
+- name: Ensure user enumeration command is modified when autofs remote home directories are used
+  block:
+      - name: Ensure that rhel8stig_auto_mount_home_dirs_local_mount_point is defined and not length zero
+        assert:
+          that:
+              - rhel8stig_auto_mount_home_dirs_local_mount_point is defined
+              - rhel8stig_auto_mount_home_dirs_local_mount_point | length > 0
+
+      - name: Modify local_interactive_user_dir_command to exclude remote automounted home directories
+        set_fact:
+            local_interactive_user_dir_command: "{{ local_interactive_user_dir_command }} | grep -v '{{ rhel8stig_auto_mount_home_dirs_local_mount_point }}"
+  when:
+      - rhel8stig_autofs_remote_home_dirs
+  tags:
+    - RHEL-08-010690
+    - complexity-high
+
 - name: "PRELIM | RHEL-08-010690 | Gather local interactive user directories"
-  # shell: "getent passwd { {{ rhel8stig_int_gid }}..65535} | cut -d: -f6 | sort -u | grep -v '/var/' | grep -v '/nonexistent/*' | grep -v '/run/*'"
-  shell: "getent passwd {% raw %}{{% endraw %}{{ rhel8stig_int_gid }}..24339{% raw %}}{% endraw %} | cut -d: -f6 | sort -u | grep -v '/var/' | grep -v '/nonexistent/*' | grep -v '/run/*'"
+  shell: "{{ local_interactive_user_dir_command }}"
   register: rhel_08_010690_getent
   changed_when: false
   failed_when: false


### PR DESCRIPTION
…mand when autofs remote home directories are used.

**Overall Review of Changes:**
* Modifies defaults/main.yml and tasks/prelim.yml files
* Migrates default getent user enumeration command to defaults/main.yml from tasks/prelim.yml
* Adds capability to RHEL8-STIG to exclude remote autofs home directories

**Issue Fixes:**
Fixes Issue [161](https://github.com/ansible-lockdown/RHEL8-STIG/issues/161)

**Enhancements:**
* Adds task block to tasks/prelim.yml with tasks to ensure required vars are defined, and to modify the local_interactive_user_dir_command when rhel8stig_auto_mount_home_dirs var is true

* Moves comments on modifying uid / gid range from tasks/prelim.yml for RHEL-08-010690 to defaults/main.yml
* Adds local_interactive_user_dir_command variable to defaults/main.yml

**How has this been tested?:**
Role tested on physical development system running RHEL 8.7 x86_64

During testing `rhel8stig_autofs_remote_home_dirs` provided as an extra var and set to true to over-ride default value.
Confirmed that task block is processed and tasks are run as expected.
Added debug task to show local_interactive_user_dir_command and validated that it's modified as expected.

```bash
ansible-playbook playbook.yml -i ~/c2_site/inventory.yml -e "@~/c2_site/c2_vars.yml" --user local --become -kK --limit c2r-vm-02.example.local -e "rhel8stig_autofs_remote_home_dirs=true"
```

```yaml
TASK [RHEL8-STIG : Ensure that rhel8stig_auto_mount_home_dirs_local_mount_point is defined and not length zero] ***************************************************************************************************
ok: [c2r-vm-02.example.local] => changed=false 
  msg: All assertions passed

TASK [RHEL8-STIG : Modify local_interactive_user_dir_command to exclude remote automounted home directories] ******************************************************************************************************
ok: [c2r-vm-02.example.local]

TASK [RHEL8-STIG : debug show local_interactive_user_dir_command] *************************************************************************************************************************************************
ok: [c2r-vm-02.example.local] => 
  local_interactive_user_dir_command: 'getent passwd { 1000..65535} | cut -d: -f6 | sort -u | grep -v ''/var/'' | grep -v ''/nonexistent/*'' | grep -v ''/run/*'' | grep -v ''/home/'
```


