### PR TITLE
Fix RHEL-08-020011 Conditional

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2799,7 +2799,7 @@
       line: "deny = {{ rhel8stig_pam_faillock.attempts }}"
   when:
       - rhel_08_020011
-      - ansible_distribution_version|int >= 8.2
+      - ansible_distribution_version is version('8.2', '>=')
   tags:
       - RHEL-08-020011
       - CAT2


### PR DESCRIPTION
**Overall Review of Changes:**
RHEL-08-020011 task currently has an incorrect conditional, `ansible_distribution_version|int >= 8.2` which will evaluate to 8 on a RHEL 8 system, meaning it will never run. This PR corrects this conditional.

**Issue Fixes:**
N/A

**Enhancements:**
Correcting RHEL-08-020011 conditional

**How has this been tested?:**
Run on RHEL 8 system
