### PR TITLE
Remove Deprecated warn from command and shell

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -104,8 +104,6 @@
 
 - name: restart auditd
   ansible.builtin.shell: /usr/sbin/service auditd restart
-  args:
-      warn: false
   when:
       - not rhel8stig_skip_for_travis
       - not rhel8stig_system_is_chroot

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -248,8 +248,6 @@
 
       - name: "MEDIUM | RHEL-08-010120 | PATCH | RHEL 8 must employ FIPS 140-2 approved cryptographic hashing algorithms for all stored passwords. | Lock user not using FIPS 140-2 hashing"
         ansible.builtin.shell: "passwd -l {{ item }}"
-        args:
-            warn: false
         with_items:
             - "{{ rhel_08_010120_non_fips_hashed_accounts.stdout_lines }}"
         when:
@@ -902,8 +900,6 @@
               "MEDIUM | RHEL-08-010310 | AUDIT | RHEL 8 system commands must be owned by root. | Get commands not owned by root"
               "MEDIUM | RHEL-08-010320 | AUDIT | RHEL 8 system commands must be group-owned by root or a system account. | Get commands no group-owned by root"
         ansible.builtin.shell: "find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin -perm /0022 -o ! -user root -o ! -group root"
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel_08_010300_commands
@@ -949,8 +945,6 @@
               "MEDIUM | RHEL-08-010340 | AUDIT | RHEL 8 library files must be owned by root. | Get library files not owned by root"
               "MEDIUM | RHEL-08-010350 | AUDIT | RHEL 8 library files must be group-owned by root or a system account. | Get library files not group-owned by root"
         ansible.builtin.shell: "find -L /lib /lib64 /usr/lib /usr/lib64 -perm /0022 -type f -o ! -user root -o ! -group root"
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel_08_010330_library_files
@@ -1396,8 +1390,6 @@
   block:
       - name: "MEDIUM | RHEL-08-010421 | AUDIT | RHEL 8 must clear the page allocator to prevent use-after-free attacks. | Get GRUB_CMDLINE_LINUX settings"
         ansible.builtin.shell: grep GRUB_CMDLINE_LINUX= /etc/default/grub | cut -f2 -d'"'
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel8stig_010421_grub_cmdline_linux
@@ -1436,8 +1428,6 @@
   block:
       - name: "MEDIUM | RHEL-08-010422 | AUDIT | RHEL 8 must disable virtual syscalls. | Get GRUB_CMDLINE_LINUX settings"
         ansible.builtin.shell: grep GRUB_CMDLINE_LINUX= /etc/default/grub | cut -f2 -d'"'
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel8stig_010422_grub_cmdline_linux
@@ -1476,8 +1466,6 @@
   block:
       - name: "MEDIUM | RHEL-08-010423 | PATCH | RHEL 8 must clear SLUB/SLAB objects to prevent use-after-free attacks. | Get GRUB_CMDLINE_LINUX settings"
         ansible.builtin.shell: grep GRUB_CMDLINE_LINUX= /etc/default/grub | cut -f2 -d'"'
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel8stig_010423_grub_cmdline_linux
@@ -1834,8 +1822,6 @@
   block:
       - name: "MEDIUM | RHEL-08-010580 | PATCH | RHEL 8 must prevent special devices on non-root local partitions. | Get mounts"
         ansible.builtin.shell: mount | grep '^/dev\S* on /\S' | grep --invert-match 'nodev' | awk '{print $1,$3,$5,$6}' | sed 's/[()]//g'
-        args:
-            warn: false
         changed_when: false
         check_mode: false
         register: rhel8stig_010580_mounts_nodev
@@ -2113,8 +2099,6 @@
   block:
       - name: "MEDIUM | RHEL-08-010660 | AUDIT | Local RHEL 8 initialization files must not execute world-writable programs. | Find world-writable files on all partitions"
         ansible.builtin.shell: find {{ item.mount }} -xdev -type f -perm -002
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel_08_010660_world_writable_files
@@ -2639,8 +2623,6 @@
   block:
       - name: "MEDIUM | RHEL-08-010780 | AUDIT | All RHEL 8 files and directories must have a valid owner. | Get nouser files"
         ansible.builtin.shell: find / -nouser
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel_08_010780_nouser_files
@@ -3323,8 +3305,6 @@
   block:
       - name: "MEDIUM | RHEL-08-020050 | AUDIT | RHEL 8 must be able to initiate directly a session lock for all connection types using smartcard when the smartcard is removed. | Find removal-action param"
         ansible.builtin.shell: 'grep "removal-action=" /etc/dconf/db/* -R | cut -f1 -d:'
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel_08_020050_removal_action
@@ -3389,8 +3369,6 @@
   block:
       - name: "MEDIUM | RHEL-08-020060 | AUDIT | RHEL 8 must automatically log out graphical user sessions after 15 minutes of inactivity. | Find idle-delay parameter"
         ansible.builtin.shell: 'grep idle-delay= /etc/dconf/db/* -R | cut -f1 -d:'
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel_08_020060_idle_delay_param
@@ -4571,8 +4549,6 @@
   block:
       - name: "MEDIUM | RHEL-08-030110 | AUDIT | RHEL 8 audit log directory must be group-owned by root to prevent unauthorized read access. | Get audit log directory"
         ansible.builtin.shell: grep -iw log_file /etc/audit/auditd.conf | cut -f3 -d" " | sed 's,/*[^/]\+/*$,,'
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel_08_030110_audit_log_dir
@@ -6036,8 +6012,6 @@
   block:
       - name: "MEDIUM | RHEL-08-040110 | AUDIT | RHEL 8 wireless network adapters must be disabled. | check if nmcli command is available"
         ansible.builtin.shell: rpm -q NetworkManager
-        args:
-            warn: false
         check_mode: false
         changed_when: false
         register: rhel_08_nmcli_available
@@ -6045,8 +6019,6 @@
 
       - name: "MEDIUM | RHEL-08-040110 | AUDIT | RHEL 8 wireless network adapters must be disabled. | check if wifi is enabled"
         ansible.builtin.shell: nmcli radio wifi
-        args:
-            warn: false
         register: rhel_08_wifi_enabled
         check_mode: false
         changed_when: rhel_08_wifi_enabled.stdout != "disabled"
@@ -6114,8 +6086,6 @@
             "MEDIUM | RHEL-08-040121 | AUDIT | RHEL 8 must mount /dev/shm with the nosuid option."
             "MEDIUM | RHEL-08-040122 | AUDIT | RHEL 8 must mount /dev/shm with the noexec option."
         ansible.builtin.shell: mount | grep /dev/shm
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel8stig_040120_dev_shm_status

--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -303,8 +303,6 @@
 
       - name: "LOW | RHEL-08-030601 | PATCH | RHEL 8 must enable auditing of processes that start prior to the audit daemon. | Set audit to 1 as active"
         ansible.builtin.shell: grubby --update-kernel=ALL --args="audit=1"
-        args:
-            warn: false
         when: (ansible_proc_cmdline.audit is defined and ansible_proc_cmdline.audit != '1') or
               (ansible_proc_cmdline.audit is not defined)
 
@@ -342,8 +340,6 @@
 
       - name: "LOW | RHEL-08-030602 | PATCH | RHEL 8 must allocate an audit_backlog_limit of sufficient size to capture processes that start prior to the audit daemon. | set audit_backlog_limit active"
         ansible.builtin.shell: grubby --update-kernel=ALL --args="audit_backlog_limit=8192"
-        args:
-            warn: false
         when: (ansible_proc_cmdline.audit_backlog_limit is defined and ansible_proc_cmdline.audit_backlog_limit != '8192') or
               (ansible_proc_cmdline.audit_backlog_limit is not defined)
 
@@ -429,15 +425,11 @@
   block:
       - name: "LOW | RHEL-08-040004 | PATCH | RHEL 8 must enable mitigations against processor-based vulnerabilities. | Set pti=on active"
         ansible.builtin.shell: grubby --update-kernel=ALL --args="pti=on"
-        args:
-            warn: false
         when: (ansible_proc_cmdline.pti is defined and ansible_proc_cmdline.pti != 'on') or
               (ansible_proc_cmdline.pti is not defined )
 
       - name: "LOW | RHEL-08-040004 | AUDIT | RHEL 8 must enable mitigations against processor-based vulnerabilities. | Get GRUB_CMDLINE_LINUX settings"
         ansible.builtin.shell: grep GRUB_CMDLINE_LINUX= /etc/default/grub | cut -f2 -d'"'
-        args:
-            warn: false
         changed_when: false
         failed_when: false
         register: rhel8stig_040004_grub_cmdline_linux

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -166,8 +166,6 @@
 
 - name: "PRELIM | RHEL-08-010020 | Check if /boot or /boot/efi reside on separate partitions"
   shell: df --output=target /boot | tail -n 1
-  args:
-      warn: false
   changed_when: false
   check_mode: false
   register: rhel_08_boot_part
@@ -288,8 +286,6 @@
 
 - name: "MEDIUM | RHEL-08-010660 | RHEL-08-010770 | AUDIT | Find ini files for interactive users."
   shell: find "{{ item }}" -maxdepth 1 -type f | grep '/\.[^/]*'
-  args:
-      warn: false
   with_items: "{{ rhel_08_stig_interactive_homedir_results }}"
   register: rhel_08_010770_ini_file_list
   changed_when: false


### PR DESCRIPTION
Signed-off-by: Jacob Buskirk <jbuskirk1995@gmail.com>

**Overall Review of Changes:**
Removal of any warn parameters from command and shell. This was deprecated in Ansible 2.14

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL8-STIG/issues/194

**Enhancements:**
N/A

**How has this been tested?:**
Run against RHEL 8 server using Ansible 2.14
