### PR TITLE
Fixed typo in user password assertion

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
         ansible.builtin.assert:
             that: ansible_user_password_set.stdout | length != 0 and ansible_user_password_set.stdout != "!!"
             fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} has no password set - It can break access"
-            success_msg: "You a password set for the {{ ansible_env.SUDO_USER }}"
+            success_msg: "You have a password set for the {{ ansible_env.SUDO_USER }}"
         vars:
             sudo_password_rule: RHEL-08-010380
   when:


### PR DESCRIPTION
Fixed typo in user password assertion

**Overall Review of Changes:**
Fixed a typo that I noticed while running this playbook today

**Issue Fixes:**
None

**Enhancements:**
None

**How has this been tested?:**
N/A
