### PR TITLE
improve password check

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changes to RHEL8STIG
 
+## 2.9.2
+
+- #216 check that sudo user has a password check improvement
+  - thanks to manish on discord for highlighting this
+
 ## 2.9.1
 
 - Issue #204 address

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,6 +66,7 @@
             sudo_password_rule: RHEL-08-010380
   when:
       - rhel_08_010380
+      - ansible_env.SUDO_USER is defined
       - not system_is_ec2
   tags:
       - user_passwd


### PR DESCRIPTION
Overall Review of Changes:
Improve password check for rule 010380 that sudo user must have a password or sudo will fail to work.

Issue Fixes:
https://github.com/ansible-lockdown/RHEL8-STIG/issues/216

Enhancements:
Only run if the playbook is not being run as a super user

How has this been tested?:
Manually
