### PR TITLE
Updated when on line 197 of prelim to use an or instead of and

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -194,8 +194,8 @@
   failed_when: false
   register: local_home_directories
   when:
-      - rhel_08_010730
-      - rhel_08_020352
+      - rhel_08_010730 or
+        rhel_08_020352
   tags:
       - always
 


### PR DESCRIPTION
**Overall Review of Changes:**
Changed the when statement for the prelim task to get local home directories to an OR statement for control toggles. This was an issue found via an Automation Counselor client. 

**Issue Fixes:**
- Incorrect and/or logic in the prelim task to get the list of local home directories fixed

**Enhancements:**
None

**How has this been tested?:**
Locally
