### PR TITLE
Change sysctl from template to sysctl module

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,16 +5,6 @@
   when:
       - not system_is_container
 
-- name: update sysctl
-  ansible.builtin.template:
-      src: 99-sysctl.conf.j2
-      dest: /etc/sysctl.d/99-sysctl.conf
-      owner: root
-      group: root
-      mode: 0644
-  notify: sysctl system
-  when: "'procps-ng' in ansible_facts.packages"
-
 - name: sysctl system
   ansible.builtin.shell: sysctl --system
   when: "'procps-ng' in ansible_facts.packages"

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1201,11 +1201,13 @@
 
 - name: "MEDIUM | RHEL-08-010372 | PATCH | RHEL 8 must prevent the loading of a new kernel for later execution."
   block:
-      - name: "MEDIUM | RHEL-08-010372 | PATCH | RHEL 8 must prevent the loading of a new kernel for later execution. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-010372 | PATCH | RHEL 8 must prevent the loading of a new kernel for later execution. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: kernel.kexec_load_disabled
+            value: 1
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
 
       - name: "MEDIUM | RHEL-08-010372 | AUDIT | RHEL 8 must prevent the loading of a new kernel for later execution. | Find conflicting instances"
         ansible.builtin.shell: grep -rs "kernel.kexec_load_disabled = 0" /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf /etc/sysctl.conf /etc/sysctl.d/*.conf | cut -d':' -f1
@@ -1247,11 +1249,13 @@
         loop: "{{ rhel_08_010373_conflicting_settings.stdout_lines }}"
         when: rhel_08_010373_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-010373 | PATCH | RHEL 8 must enable kernel parameters to enforce discretionary access control on symlinks. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-010373 | PATCH | RHEL 8 must enable kernel parameters to enforce discretionary access control on symlinks. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: fs.protected_symlinks
+            value: 1
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_010373
   tags:
@@ -1280,10 +1284,12 @@
         when: rhel_08_010374_conflicting_settings.stdout | length > 0
 
       - name: "MEDIUM | RHEL-08-010374 | PATCH | RHEL 8 must enable kernel parameters to enforce discretionary access control on hardlinks."
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+        sysctl:
+            name: fs.protected_symlinks
+            value: 1
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_010374
   tags:
@@ -1565,11 +1571,13 @@
         loop: "{{ rhel_08_010430_conflicting_settings.stdout_lines }}"
         when: rhel_08_010430_conflicting_settings.stdout | length > 0
 
-      - name: " MEDIUM | RHEL-08-010430 | PATCH | RHEL 8 must implement address space layout randomization (ASLR) to protect its memory from unauthorized code execution. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: " MEDIUM | RHEL-08-010430 | PATCH | RHEL 8 must implement address space layout randomization (ASLR) to protect its memory from unauthorized code execution. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: kernel.randomize_va_space
+            value: 2
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_010430
   tags:
@@ -2224,10 +2232,12 @@
         when: rhel_08_010671_conflicting_settings.stdout | length > 0
 
       - name: "MEDIUM | RHEL-08-010671 | PATCH | RHEL 8 must disable the kernel.core_pattern."
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+        sysctl:
+            name: kernel.core_pattern
+            value: "|/bin/false"
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_010671
   tags:
@@ -6614,11 +6624,13 @@
         loop: "{{ rhel_08_040209_conflicting_settings.stdout_lines }}"
         when: rhel_08_040209_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040209 | PATCH | RHEL 8 must prevent IPv4 Internet Control Message Protocol (ICMP) redirect messages from being accepted. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040209 | PATCH | RHEL 8 must prevent IPv4 Internet Control Message Protocol (ICMP) redirect messages from being accepted. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv4.conf.default.accept_redirects
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040209
   tags:
@@ -6646,11 +6658,13 @@
         loop: "{{ rhel_08_040210_conflicting_settings.stdout_lines }}"
         when: rhel_08_040210_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040210 | PATCH | RHEL 8 must prevent IPv6 Internet Control Message Protocol (ICMP) redirect messages from being accepted. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040210 | PATCH | RHEL 8 must prevent IPv6 Internet Control Message Protocol (ICMP) redirect messages from being accepted. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv6.conf.default.accept_redirects
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
 
   when:
       - rhel_08_040210
@@ -6680,11 +6694,13 @@
         loop: "{{ rhel_08_040220_conflicting_settings.stdout_lines }}"
         when: rhel_08_040220_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040220 | PATCH | RHEL 8 must not send Internet Control Message Protocol (ICMP) redirects. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040220 | PATCH | RHEL 8 must not send Internet Control Message Protocol (ICMP) redirects. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv4.conf.all.send_redirects
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040220
   tags:
@@ -6712,11 +6728,13 @@
         loop: "{{ rhel_08_040230_conflicting_settings.stdout_lines }}"
         when: rhel_08_040230_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040230 | PATCH | The RHEL 8 must not respond to Internet Control Message Protocol (ICMP) echoes sent to a broadcast address. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040230 | PATCH | The RHEL 8 must not respond to Internet Control Message Protocol (ICMP) echoes sent to a broadcast address. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv4.icmp_echo_ignore_broadcasts
+            value: 1
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040230
   tags:
@@ -6744,11 +6762,13 @@
         loop: "{{ rhel_08_040239_conflicting_settings.stdout_lines }}"
         when: rhel_08_040239_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040239 | PATCH | RHEL 8 must not forward IPv4 source-routed packets. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040239 | PATCH | RHEL 8 must not forward IPv4 source-routed packets. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv4.conf.all.accept_source_route
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040239
   tags:
@@ -6776,11 +6796,13 @@
         loop: "{{ rhel_08_040240_conflicting_settings.stdout_lines }}"
         when: rhel_08_040240_conflicting_settings.stdout |length > 0
 
-      - name: "MEDIUM | RHEL-08-040240 | PATCH | RHEL 8 must not forward IPv6 source-routed packets. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040240 | PATCH | RHEL 8 must not forward IPv6 source-routed packets. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv6.conf.all.accept_source_route
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040240
       - rhel8stig_ipv6_required
@@ -6809,11 +6831,13 @@
         loop: "{{ rhel_08_040249_conflicting_settings.stdout_lines }}"
         when: rhel_08_040249_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040249 | PATCH | RHEL 8 must not forward IPv4 source-routed packets by default. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040249 | PATCH | RHEL 8 must not forward IPv4 source-routed packets by default. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv4.conf.default.accept_source_route
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040249
   tags:
@@ -6841,11 +6865,13 @@
         loop: "{{ rhel_08_040250_conflicting_findings.stdout_lines }}"
         when: rhel_08_040250_conflicting_findings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040250 | PATCH | RHEL 8 must not forward IPv6 source-routed packets by default. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040250 | PATCH | RHEL 8 must not forward IPv6 source-routed packets by default. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv6.conf.default.accept_source_route
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040250
       - rhel8stig_ipv6_required
@@ -6874,11 +6900,13 @@
         loop: "{{ rhel_08_040259_conflicting_settings.stdout_lines }}"
         when: rhel_08_040259_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040259 | PATCH | RHEL 8 must not enable IPv4 packet forwarding unless the system is a router. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040259 | PATCH | RHEL 8 must not enable IPv4 packet forwarding unless the system is a router. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv4.conf.all.forwarding
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040259
       - not rhel8stig_system_is_router
@@ -6907,11 +6935,13 @@
         loop: "{{ rhel_08_040260_conflicting_settings.stdout_lines }}"
         when: rhel_08_040260_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040260 | PATCH | RHEL 8 must not enable IPv6 packet forwarding unless the system is a router. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040260 | PATCH | RHEL 8 must not enable IPv6 packet forwarding unless the system is a router. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv6.conf.all.forwarding
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040260
       - not rhel8stig_system_is_router
@@ -6940,11 +6970,13 @@
         loop: "{{ rhel_08_040261_conflicting_settings.stdout_lines }}"
         when: rhel_08_040261_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040261 | PATCH | RHEL 8 must not accept router advertisements on all IPv6 interfaces. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040261 | PATCH | RHEL 8 must not accept router advertisements on all IPv6 interfaces. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv6.conf.all.accept_ra
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040261
       - rhel8stig_ipv6_required
@@ -6974,11 +7006,13 @@
         loop: "{{ rhel_08_040262_conflicting_settings.stdout_lines }}"
         when: rhel_08_040262_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040262 | PATCH | RHEL 8 must not accept router advertisements on all IPv6 interfaces by default. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040262 | PATCH | RHEL 8 must not accept router advertisements on all IPv6 interfaces by default. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv6.conf.default.accept_ra
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040262
       - rhel8stig_ipv6_required
@@ -7008,11 +7042,13 @@
         loop: "{{ rhel_08_040270_conflicting_settings.stdout_lines }}"
         when: rhel_08_040270_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040270 | PATCH | The RHEL 8 must not allow interfaces to perform Internet Control Message Protocol (ICMP) redirects by default. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040270 | PATCH | The RHEL 8 must not allow interfaces to perform Internet Control Message Protocol (ICMP) redirects by default. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv4.conf.default.send_redirects
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040270
   tags:
@@ -7040,11 +7076,13 @@
         loop: "{{ rhel_08_040279_conflicting_settings.stdout_lines }}"
         when: rhel_08_040279_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040279 | PATCH | RHEL 8 must ignore IPv4 Internet Control Message Protocol (ICMP) redirect messages. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040279 | PATCH | RHEL 8 must ignore IPv4 Internet Control Message Protocol (ICMP) redirect messages. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv4.conf.all.accept_redirects
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040279
   tags:
@@ -7072,11 +7110,13 @@
         loop: "{{ rhel_08_040280_conflicting_settings.stdout_lines }}"
         when: rhel_08_040280_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040280 | PATCH | RHEL 8 must ignore IPv6 Internet Control Message Protocol (ICMP) redirect messages. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040280 | PATCH | RHEL 8 must ignore IPv6 Internet Control Message Protocol (ICMP) redirect messages. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv6.conf.all.accept_redirects
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040280
       - rhel8stig_ipv6_required
@@ -7105,11 +7145,13 @@
         loop: "{{ rhel_08_040281_conflicting_settings.stdout_lines }}"
         when: rhel_08_040281_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040281 | PATCH | RHEL 8 must disable access to network bpf syscall from unprivileged processes. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040281 | PATCH | RHEL 8 must disable access to network bpf syscall from unprivileged processes. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: kernel.unprivileged_bpf_disabled
+            value: 1
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040281
   tags:
@@ -7137,11 +7179,13 @@
         loop: "{{ rhel_08_040282_conflicting_settings.stdout_lines }}"
         when: rhel_08_040282_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040282 | PATCH | RHEL 8 must restrict usage of ptrace to descendant processes. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040282 | PATCH | RHEL 8 must restrict usage of ptrace to descendant processes. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: kernel.yama.ptrace_scope
+            value: 1
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040282
   tags:
@@ -7169,11 +7213,13 @@
         loop: "{{ rhel_08_040283_conflicting_settings.stdout_lines }}"
         when: rhel_08_040283_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040283 | PATCH | RHEL 8 must restrict exposed kernel pointer addresses access. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040283 | PATCH | RHEL 8 must restrict exposed kernel pointer addresses access. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: kernel.kptr_restrict
+            value: 1
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040283
   tags:
@@ -7201,11 +7247,13 @@
         loop: "{{ rhel_08_040284_conflicting_settings.stdout_lines }}"
         when: rhel_08_040284_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040284 | PATCH | RHEL 8 must disable the use of user namespaces. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040284 | PATCH | RHEL 8 must disable the use of user namespaces. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: user.max_user_namespaces
+            value: 0
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040284
   tags:
@@ -7233,11 +7281,13 @@
         loop: "{{ rhel_08_040285_conflicting_settings.stdout_lines }}"
         when: rhel_08_040285_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040285 | PATCH | RHEL 8 must use reverse path filtering on all IPv4 interfaces. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040285 | PATCH | RHEL 8 must use reverse path filtering on all IPv4 interfaces. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.ipv4.conf.all.rp_filter
+            value: 1
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040285
   tags:
@@ -7265,11 +7315,13 @@
         loop: "{{ rhel_08_040286_conflicting_settings.stdout_lines }}"
         when: rhel_08_040286_conflicting_settings.stdout | length > 0
 
-      - name: "MEDIUM | RHEL-08-040286 | PATCH | RHEL 8 must enable hardening for the Berkeley Packet Filter Just-in-time compiler. | Use template to create file"
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+      - name: "MEDIUM | RHEL-08-040286 | PATCH | RHEL 8 must enable hardening for the Berkeley Packet Filter Just-in-time compiler. | Apply sysctl.conf Configuration"
+        sysctl:
+            name: net.core.bpf_jit_harden
+            value: 2
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_040286
   tags:

--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -49,10 +49,12 @@
         when: rhel_08_010375_conflicting_settings.stdout | length > 0
 
       - name: "LOW | RHEL-08-010375 | PATCH | RHEL 8 must restrict access to the kernel message buffer."
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+        sysctl:
+            name: kernel.dmesg_restrict
+            value: 1
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_010375
   tags:
@@ -81,10 +83,12 @@
         when: rhel_08_010376_conflicting_settings.stdout | length > 0
 
       - name: "LOW | RHEL-08-010376 | PATCH | RHEL 8 must prevent kernel profiling by unprivileged users."
-        ansible.builtin.debug:
-            msg: "Control being set via Handler 'update sysctl' which writes to /etc/sysctl.d/99-sysctl.conf"
-        changed_when: true
-        notify: update sysctl
+        sysctl:
+            name: kernel.perf_event_paranoid
+            value: 2
+            state: present
+            reload: "{{ rhel8stig_sysctl_reload }}"
+            sysctl_set: true
   when:
       - rhel_08_010376
   tags:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,7 +10,7 @@ rhel8stig_service_started: "{{ rhel8stig_system_is_chroot | ternary(omit, 'start
 # !!!!!!!!possibly delete
 # rhel8stig_systemd_daemon_reload: "{{ not rhel8stig_system_is_chroot }}"
 
-rhel8stig_sysctl_reload: "{{ not rhel8stig_system_is_container }}"
+rhel8stig_sysctl_reload: "{{ not system_is_container }}"
 
 # these variables are for enabling tasks to run that will be further controled
 # by check_mode to prevent the remediation task from making changes as


### PR DESCRIPTION
**Overall Review of Changes:**
Change sysctl from using a template to sysctl module. This also changes it to write to /etc/sysctl.conf instead of overwriting the default RHEL 8 symlink at /etc/sysctl.d/99-sysctl.conf

**Issue Fixes:**
#229 

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Tested against RHEL 8 server

