### PR TITLE
Update main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -845,10 +845,6 @@ rhel8stig_path_to_sshkey: "/root/.ssh/"
 # To conform to STIG standards these directories need to be 755 or less permissive
 rhel8stig_lib_dir_perms: 0755
 
-# RHEL-08-010510
-# rhel8stig_sshd_compression to meet STIG requirements needs to be set to "no" or "delayed"
-rhel8stig_sshd_compression: "no"
-
 # now in prelim
 # rhel8stig_interactive_uid_start: '1000'
 


### PR DESCRIPTION
Removing stale var `rhel8stig_sshd_compression` in `defaults/main.yml`

**Overall Review of Changes:**
The task addressing RHEL-08-010510 was removed in Release 2.8.0. `rhel8stig_sshd_compression` variable remained in `defaults/main.yml`

**Issue Fixes:**
N/A

**Enhancements:**
Stale variable removal from `defaults/main.yml`

**How has this been tested?:**
N/A there are no references to stale var outside of declaration

