### PR TITLE
Adds when criteria for rhel_08_040321 in task/fix-cat2.yml, to skip t…

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -7401,6 +7401,7 @@
       state: link
   when:
       - rhel_08_040321
+      - not rhel8stig_gui
   tags:
       - RHEL-08-040321
       - CAT2


### PR DESCRIPTION
…he task when rhel8stig_gui is set to true

**Overall Review of Changes:**
Updates RHEL_08_040321 to consider rhel8stig_gui variable state

**Issue Fixes:**
Fixes issue #243 

**Enhancements:**
None

**How has this been tested?:**
Tested on RHEL 8 Linux Workstation with graphical.target set as systemctl default and graphical desktop installed.

