### PR TITLE
Adds when criteria for rhel_08_040321 in tasks/fix-cat2.yml, to skip …

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -7401,6 +7401,7 @@
       state: link
   when:
       - rhel_08_040321
+      - not rhel8stig_gui
   tags:
       - RHEL-08-040321
       - CAT2


### PR DESCRIPTION
…the task when rhel8stig_gui is set to true, resolves issue #243

**Overall Review of Changes:**
Adds when check for rhel8stig_gui variable to RHEL-08-040321

**Issue Fixes:**
Issue #243 

**Enhancements:**
N/A

**How has this been tested?:**
Validated in our development environment.  
GUI remains operational and in the proper state after running the RHEL8-STIG role.

