### PR TITLE
Oracle Linux rhel8stig_bootloader_path and RHEL-08-020030 fix

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -3260,7 +3260,7 @@
 - name: "MEDIUM | RHEL-08-020030 | PATCH | RHEL 8 must enable a user session lock until that user re-establishes access using established identification and authentication procedures for graphical user sessions."
   block:
       - name: "MEDIUM | RHEL-08-020030 | AUDIT | RHEL 8 must enable a user session lock until that user re-establishes access using established identification and authentication procedures for graphical user sessions. | Check for lock-enabled"
-        ansible.builtin.shell: "grep lock-enabled /etc/dconf/db/* -r | cut -f1 -d:"
+        ansible.builtin.shell: "grep lock-enabled /etc/dconf/db/* -rI | sort -u | tail -n 1 | cut -f1 -d:"
         changed_when: false
         failed_when: false
         register: rhel_08_020030_lock_enabled

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -386,7 +386,7 @@
             rhel8stig_legacy_boot: false
         when:
             - rhel8_efi_boot.stat.exists
-            - ansible_distribution == 'Oracle Linux'
+            - ansible_distribution == 'OracleLinux'
 
       - name: "PRELIM | set if not UEFI boot"
         ansible.builtin.set_fact:


### PR DESCRIPTION
Addressing Oracle Linux distribution identification issue https://github.com/ansible-lockdown/RHEL8-STIG/issues/239

**Overall Review of Changes:**
- Oracle Linux distribution was being incorrectly identified in the `prelim.yml` task
- `RHEL-08-020030` related task fails if `lock-enabled` is already defined in dconf

**Issue Fixes:**
Resolves #239
Resolves #241

**Enhancements:**
N/A

**How has this been tested?:**
- Ansible 2.16
- Oracle Linux 8.8

1. Observed successful variable assignment of `rhel8stig_bootloader_path` to `/boot/efi/EFI/redhat`
```
TASK [ansible-lockdown.RHEL8-STIG : PRELIM | set fact if UEFI boot | Oracle Linux] *******
ok: [localhost] => {"ansible_facts": {"rhel8stig_bootloader_path": "/boot/efi/EFI/redhat", "rhel8stig_legacy_boot": false}, "changed": false}
...
...
...
TASK [ansible-lockdown.RHEL8-STIG : PRELIM | output bootloader and efi state] ************
ok: [localhost] => {
    "msg": [
        "bootloader path set to /boot/efi/EFI/redhat",
        "legacy boot equals False"
    ]
}
```
2. Observed successful enforcement of `lock-enabled=true` if `lock-enabled` was already implemented in dconf