### PR TITLE
Remove duplicate and templated task tags

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -19,4 +19,6 @@ skip_list:
     - '602'
     - '208'
 use_default_rules: true
+rulesdir:
+    - ./rules/
 verbosity: 0

--- a/rules/tag.py
+++ b/rules/tag.py
@@ -1,0 +1,63 @@
+"""Implementation of TagRule."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from ansiblelint.constants import LINE_NUMBER_KEY
+from ansiblelint.file_utils import Lintable
+from ansiblelint.rules import AnsibleLintRule, TransformMixin
+
+if TYPE_CHECKING:
+    from ansiblelint.errors import MatchError
+    from ansiblelint.utils import Task
+
+
+class TagRule(AnsibleLintRule, TransformMixin):
+    """Rule for checking task tags."""
+
+    id = "tag"
+    description = (
+        "All task tags should have distinct names"
+        "and templates in tags should be avoided."
+    )
+    severity = "MEDIUM"
+    tags = ["idiom"]
+    _re_templated = re.compile(r"^.*\{\{.*\}\}.*$")
+    _ids = {
+        "tag[no-duplicate]": "Tasks should not duplicate tags.",
+        "tag[no-template]": "Tasks should not use Jinja templates in tags.",
+    }
+
+    def matchtask(
+        self,
+        task: Task,
+        file: Lintable | None = None,
+    ) -> list[MatchError]:
+        results: list[MatchError] = []
+        if file and file.failed():
+            return results
+        tags = task.get("tags")
+        if tags:
+            if len(tags) != len(set(tags)):
+                results.append(
+                    self.create_matcherror(
+                        message="Tasks should not duplicate tags.",
+                        lineno=task[LINE_NUMBER_KEY],
+                        tag="tag[no-duplicate]",
+                        filename=file,
+                    ),
+                )
+            for tag in tags:
+                if self._re_templated.match(tag):
+                    results.append(
+                        self.create_matcherror(
+                            message="Tasks should not use Jinja templates in tags.",
+                            lineno=task[LINE_NUMBER_KEY],
+                            tag="tag[no-template]",
+                            filename=file,
+                        ),
+                    )
+                    break
+        return results

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -2733,7 +2733,6 @@
   tags:
       - RHEL-08-010830
       - CAT2
-      - V-230330
       - CCI-000366
       - SRG-OS-000480-GPOS-00229
       - SV-230330r858713_rule
@@ -5973,7 +5972,8 @@
       - SV-230505r744020_rule
       - V-230505
       - firewall
-      - "{{ rhel8stig_firewall_service }}"
+      - iptables
+      - firewalld
 
 - name: "MEDIUM | RHEL-08-040101 | PATCH | A firewall must be active on RHEL 8"
   block:


### PR DESCRIPTION
**Overall Review of Changes:**

This PR removes tags from tasks that are either duplicated or templated (via jinja).

**Issue Fixes:**

#296 

**How has this been tested?:**

- Manual running of playbook as described in linked issue.
- Manually verified failure of pre-commit hook prior to addressing the bug.
- Manually verified success of pre-commit hook after addressing the bug.

